### PR TITLE
feat(datapane): Add `bokeh.layouts` support

### DIFF
--- a/src/datapane/client/files.py
+++ b/src/datapane/client/files.py
@@ -80,6 +80,7 @@ import pandas as pd
 from altair.utils import SchemaBase
 from bokeh.embed import json_item
 from bokeh.plotting.figure import Figure as BFigure
+from bokeh.layouts import LayoutDOM as BLayout
 from folium import Map
 from matplotlib.figure import Axes, Figure
 from numpy import ndarray
@@ -205,15 +206,26 @@ class TablePlot(BasePlot):
             dataframe.to_html(f)
 
 
-class BokehPlot(BasePlot):
-    """Returns an interactive Bokeh application"""
-
+class BokehBasePlot(BasePlot):
     mimetype = "application/vnd.bokeh.show+json"
     ext = ".bokeh.json"
+
+    def _write_file(self, f: TextIO, app: any) -> DPTmpFile:
+        json.dump(json_item(app), f)
+
+class BokehPlot(BokehBasePlot):
+    """Returns an interactive Bokeh application"""
     fig_type = BFigure
 
-    def write_file(self, f: TextIO, app: BFigure):
-        json.dump(json_item(app), f)
+    def write_file(self, f: TextIO, app: BFigure) -> DPTmpFile:
+        super()._write_file(f, app)
+
+
+class BokehLayoutPlot(BokehBasePlot):
+    fig_type = BLayout
+
+    def write_file(self, f: TextIO, app: BLayout) -> DPTmpFile:
+        super()._write_file(f, app)
 
 
 class AltairPlot(BasePlot):
@@ -256,6 +268,7 @@ class FoliumPlot(BasePlot):
 plots = [
     TablePlot,
     BokehPlot,
+    BokehLayoutPlot,
     AltairPlot,
     PlotlyPlot,
     FoliumPlot,

--- a/tests/client/test_files.py
+++ b/tests/client/test_files.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 from bokeh.models import ColumnDataSource
 from bokeh.plotting import figure
+from bokeh.layouts import column
 
 from datapane.client.files import save
 
@@ -41,6 +42,13 @@ def test_save_bokeh(tmp_path: Path):
     p = figure()
     p.circle(x="x", y="y", source=source)
     save(p)
+
+
+def test_save_bokeh_layout(tmp_path: Path):
+    source = ColumnDataSource(data)
+    p = figure()
+    p.circle(x="x", y="y", source=source)
+    save(column(p, p))
 
 
 def test_save_altair(tmp_path: Path):


### PR DESCRIPTION
Hi there, thanks for the nice project!

I want to visualize an interactive plot with a slider using Bokeh (like Altair sample) but this library does not support `bokeh.layout` with the current version.
This PR enables to plot `bokeh.layout.row`, `bokeh.layout.column`, and other `bokeh.LayoutDOM` objects.
An example is below. ↓
<img width="735" alt="demo" src="https://user-images.githubusercontent.com/25083790/96902777-e7857100-14cf-11eb-8c87-e310b72b11d3.png">
```python
layout = row(
    plot,
    column(amp_slider, freq_slider, phase_slider, offset_slider),
)

dp.Report(dp.Plot(layout)).preview()
```
https://docs.bokeh.org/en/latest/docs/gallery/slider.html


## Prerequsites

- [x] Has been tested locally
- [x] If a bugfix, have included a breaking test if possible

## Proposed Changes

- class `Plot` becomes able to render instances of `bokeh.LayoutDOM`.
