### PR TITLE
Enable to show timedelta in Table

### DIFF
--- a/src/datapane/common/df_processor.py
+++ b/src/datapane/common/df_processor.py
@@ -41,6 +41,18 @@ def parse_dates(data: pd.DataFrame, force_utc: bool = False):
     data[potential_dates.columns] = potential_dates.apply(try_to_datetime)
 
 
+def parse_timedelta(data: pd.DataFrame):
+    """Tries to convert strings to timedelta, ignores existing panda timedelta"""
+
+    # if timedelta is not parsed, it might be interpreted as categories or strings
+    potential_timedeltas = data.select_dtypes(object)
+
+    def try_to_timedelta(ser: pd.Series) -> pd.Series:
+        return pd.to_timedelta(ser, errors="ignore")
+
+    data[potential_timedeltas.columns] = potential_timedeltas.apply(try_to_timedelta)
+
+
 def parse_categories(data: pd.DataFrame):
     """Detect and converts categories"""
     potential_cats = data.select_dtypes(object)
@@ -107,6 +119,7 @@ def process_df(df: pd.DataFrame) -> None:
     """
     convert_indices(df)
     parse_dates(df)
+    parse_timedelta(df)
     parse_categories(df)
     downcast_numbers(df)
     to_str(df)
@@ -146,7 +159,7 @@ def to_df(value: Any) -> pd.DataFrame:
 
         return pd.DataFrame({"Result": value})
 
-    if isinstance(value, (Number, str, bool, datetime.datetime)):
+    if isinstance(value, (Number, str, bool, datetime.datetime, datetime.timedelta)):
         return pd.DataFrame({"Result": value}, index=[0])
 
     if isinstance(value, np.ndarray):

--- a/src/datapane/common/df_processor.py
+++ b/src/datapane/common/df_processor.py
@@ -18,12 +18,7 @@ def convert_indices(df: pd.DataFrame):
     """
     col_names: List[str] = df.columns.values.tolist()
     if (
-        all(
-            [
-                df.index.get_level_values(x).dtype != np.dtype("int64")
-                for x in range(df.index.nlevels)
-            ]
-        )
+        all([df.index.get_level_values(x).dtype != np.dtype("int64") for x in range(df.index.nlevels)])
         and len(set(df.index.names)) == len(df.index.names)
         and not any([x in col_names for x in df.index.names])
     ):

--- a/tests/common/test_df_processor_2.py
+++ b/tests/common/test_df_processor_2.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import timedelta
 
 import numpy as np
 import pandas as pd
@@ -79,6 +80,11 @@ def test_to_df_datetime():
 def test_to_df_datetime_timezoned():
     now = pd.to_datetime("now", utc=True)
     assert_scalar_works(now)
+
+
+def test_to_df_timedelta():
+    delta = pd.to_timedelta(timedelta(days=1, seconds=10000, microseconds=100000))
+    assert_scalar_works(delta)
 
 
 def test_to_df_2_dim_numpy_array():


### PR DESCRIPTION
Hi, thank you for your reviews of the previous PR.

I want to use `datapane.Table` to visualize a result of training in ML.
In the current version, the type of `timedelta`  is downcasted to `int` and it is hard to understand.
This PR enables the display `timedelta` object as it is.

current version
<img width="647" alt="before" src="https://user-images.githubusercontent.com/25083790/97390424-309a5280-1920-11eb-874c-31100dce381c.png">
proposal version
<img width="645" alt="after" src="https://user-images.githubusercontent.com/25083790/97390429-32641600-1920-11eb-828c-f1bd3ffe6d83.png">
code
```python
import random
from datetime import timedelta
from random import randint

import numpy as np
import pandas as pd

import datapane as dp

random.seed(42)
np.random.seed(42)

metrics = pd.DataFrame(np.random.rand(3, 2))
delta = pd.DataFrame(
    [timedelta(days=randint(0, 1), seconds=randint(0, 86399), microseconds=randint(0, 999999)) for _ in range(3)]
)

df = pd.concat([metrics, delta], axis=1)
df.columns = ["MAE", "RMSE", "learning time"]

dp.Report(dp.Table(df)).preview()
```

## Prerequsites

- [x] Has been tested locally
- [x] If a bugfix, have included a breaking test if possible

## Proposed Changes

- convert timedelta64[ns] to str 

`timedelta64[ns]` (`duration` in pyarrow) is not supported in Apache Parquet, so that converts it to `str`.

If the number of columns is under 20, strings are parsed as categories and else,  as it is by `parse_categories`.
Because of this ambiguity, I convert `str` interpreted as `datetime64[ns]` to `datetime64[ns]` explicitly and to `str` again.  