### PR TITLE
Change jinja2 import for contextfunction to pass_context

### DIFF
--- a/src/datapane/client/api/report/core.py
+++ b/src/datapane/client/api/report/core.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from uuid import uuid4
 
 import importlib_resources as ir
-from jinja2 import Environment, FileSystemLoader, Template, contextfunction
+from jinja2 import Environment, FileSystemLoader, Template, pass_context
 from lxml import etree
 from lxml.etree import Element, _Element
 from markupsafe import Markup  # used by Jinja
@@ -109,7 +109,7 @@ class ReportFormatting:
 # SKIP_DISPLAY_MSG = False
 
 
-@contextfunction
+@pass_context
 def include_raw(ctx, name):
     """ Normal jinja2 {% include %} doesn't escape {{...}} which appear in React's source code """
     env = ctx.environment


### PR DESCRIPTION
This field was deprecated for a while and was finally removed in https://github.com/pallets/jinja/pull/1544/files


## Prerequisites

- [x] Has been tested locally
- [ ] If a bugfix, have included a breaking test if possible

## Proposed Changes
- Rename `contextfunction` to `pass_context` in`src/datapane/client/api/report/core.py`
