### PR TITLE
chore: Introduce a Taskfile to act as our task-runner

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,69 @@
+version: '3'
+
+includes:
+
+vars:
+  PYTHON: poetry run python
+  PYTEST: "{{.PYTHON}} -m pytest"
+
+  POETRY_SKIP_INSTALL: ""
+
+  # assign defaults to our test configurations
+  ## for use by e2e + cypress
+  DP_TEST_SERVER: '{{.DP_TEST_SERVER | default "http://localhost:8090"}}'
+  DP_TEST_TOKEN: '{{.DP_TEST_TOKEN | default ""}}'
+  ## for use by cypress
+  DP_TEST_PASSWORD: '{{.DP_TEST_PASSWORD | default ""}}'
+  DP_STAFF_PASSWORD: '{{.DP_STAFF_PASSWORD | default ""}}'
+
+env:
+
+dotenv: ['.env']
+
+tasks:
+  install:
+    desc: "Install dependencies ready for development on the codebase"
+    deps: [system-check]
+    run: once
+    cmds:
+      - cmd: poetry install -E plotting -E cloud
+    status:
+      - test -n "$POETRY_SKIP_INSTALL"
+
+  test:
+    desc: "Run self-contained tests"
+    deps: [install]
+    cmds:
+      - cmd: "{{.PYTEST}} -v --ignore=tests/client/e2e/ tests"
+      - cmd: "{{.PYTEST}} -v tests_toplevel"
+
+  test:e2e:public:
+    desc: "Run all the e2e tests relating to the 'public' focused APIs"
+    deps: [install]
+    cmds:
+      - cmd: "{{.PYTEST}} tests/client/e2e/ -m 'not org'"
+    env: &e2e-env
+      DP_TEST_SERVER: '{{.DP_TEST_SERVER}}'
+      DP_TEST_TOKEN: '{{.DP_TEST_TOKEN}}'
+      DP_TEST_PASSWORD: '{{.DP_TEST_PASSWORD}}'
+      DP_STAFF_PASSWORD: '{{.DP_STAFF_PASSWORD}}'
+
+  test:e2e:org:
+    desc: "Run all the e2e tests relating to the 'Org' focused APIs"
+    deps: [install]
+    cmds:
+      - cmd: "{{.PYTEST}} tests/client/e2e/"
+    env: *e2e-env
+
+  system-check:
+    desc: Run checks to make sure you're ready for development
+    cmds:
+      - task: system-check:poetry
+
+  system-check:poetry:
+    run: once
+    preconditions:
+      - sh: command -v poetry
+        msg: >-
+          Poetry needs installing on your system: ->
+          https://python-poetry.org/docs/master/#installing-with-the-official-installer

--- a/tests_toplevel/test_config.py
+++ b/tests_toplevel/test_config.py
@@ -28,7 +28,7 @@ def mock_analytics(mock_click_path):
 
     with mock.patch("datapane.client.analytics.posthog", autospec=True) as posthog, mock.patch(
         "datapane.client.analytics._NO_ANALYTICS", False
-    ), mock.patch("datapane.client.api.user.ping", autospect=True) as ping:
+    ), mock.patch("datapane.client.api.user.ping", autospec=True) as ping:
         ping.return_value = "joebloggs@datapane.com"
         yield (posthog, mock_click_path)
 


### PR DESCRIPTION
Internally, Taskfile has been replacing our use of Makefile and PyInvoke.

It allows for easy discovery of tasks; and is a language-neutral task runner.

The taskfile is structured in a way that allows for standalone e2e testing, while
being injectable so that our monorepo can run a full e2e test.

Invocations:
```
# list documented tasks
task -l
# list ALL tasks
task --list-all

# install dependencies
task install

# run e2e tests
## ensure that `DP_TEST_TOKEN` is specified in the `.env` file
## ensure that you have a running server
task test:e2e:public
```