### PR TITLE
Chore: Introduce Deployments for the new Docs page

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,3 +4,7 @@ includes:
   python-client:
     taskfile: projects/python-client
     dir: projects/python-client
+
+  docs:
+    taskfile: docs
+    dir: docs

--- a/dev/Taskfile.template.yml
+++ b/dev/Taskfile.template.yml
@@ -1,0 +1,21 @@
+version: "3"
+
+includes:
+
+env:
+
+tasks:
+  install:
+    desc: "Install dependencies ready for development on the codebase"
+    run: once
+    cmds:
+      - cmd: echo "no-op"
+
+  test:
+    desc: "Run self-contained tests"
+
+  build:
+    desc: "Build a package ready for a deploy"
+
+  deploy:
+    desc: "Deploy the package"

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 The new Datapane documentation.
 
-# Requirements
+## Requirements
 
 1. `poetry`, as per [their instructions](https://python-poetry.org/docs/master/#installing-with-the-official-installer)
 2. `chromium`, through your package manager:
@@ -12,14 +12,20 @@ The new Datapane documentation.
     - MacOS: `brew install chromium`
     - Fedora: `sudo dnf install chromium`
 
-# Generating the docs
+## Generating the docs
 
 1. Run `poetry run ./nbbuild.sh` to execute all Jupyter notebooks and generate Datapane reports and image previews.
 2. Run `poetry run mkdocs build` to generate static site in `site/`.
 
 `poetry run mkdocs serve` can be used to serve locally.
 
-# Embedding reports and previews
+_hint:_ You can also use the same tool we use for Deploys for local serving after a build:
+
+```
+wrangler pages dev --live-reload
+```
+
+## Embedding reports and previews
 
 1. Save your report to the same directory as the notebook:
 
@@ -39,10 +45,23 @@ The new Datapane documentation.
 
 3. Mark the cell with the metadata tag `remove_input` so we only see the output.
 
-# Hiding input and/or output
+## Hiding input and/or output
 
 Use metadata to show or hide input/output cells in notebooks.
 
 -   `remove_input`, e.g. for cells containing preview code from `dpdocsutils`.
 -   `remove_all_output`, e.g. for the cells outputting information after calling `.save()` or `.upload()`.
 -   `remove_cell`, e.g. when you want something executed without displaying input or output.
+
+## Deploying
+
+We use Cloudflare Pages for hosting the docs, under the project name `datapane-docs`.
+
+You will need `wrangler` 2.x [installed][wrangler-install].
+
+1. Follow the [build](#Generating-the-docs) instructions to generate the `./site/` directory
+2. Run `task deploy`
+
+    _this will run the correct wrangler command for you based on your branch_
+
+[wrangler-install]: https://developers.cloudflare.com/workers/wrangler/get-started/

--- a/docs/Taskfile.yml
+++ b/docs/Taskfile.yml
@@ -20,6 +20,11 @@ tasks:
       - cmd: poetry run ./nbbuild.sh
       - cmd: poetry run mkdocs build
 
+  serve:
+    desc: "Serve the site locally"
+    cmds:
+      - cmd: poetry run mkdocs serve
+
   deploy:
     desc: "Deploy the package"
     cmds:

--- a/docs/Taskfile.yml
+++ b/docs/Taskfile.yml
@@ -1,0 +1,27 @@
+version: "3"
+
+includes:
+
+env:
+
+tasks:
+  install:
+    desc: "Install dependencies ready for development on the codebase"
+    run: once
+    cmds:
+      - cmd: poetry install
+
+  test:
+    desc: "Run self-contained tests"
+
+  build:
+    desc: "Build a package ready for a deploy"
+    cmds:
+      - cmd: poetry run ./nbbuild.sh
+      - cmd: poetry run mkdocs build
+
+  deploy:
+    desc: "Deploy the package"
+    cmds:
+      # wrangler pages doesn't support a config file yet
+      - cmd: wrangler pages publish --project-name datapane-docs site


### PR DESCRIPTION
Utilise Cloudflare Pages for Docs hosting.

Cloudflare will publish the page to your branch name, and to the current commit hash.

As part of this, a think Taskfile has been introduced to allow for self-discovery of projects + commands for the docs project.

CI changes will follow in a separate PR once we're done with manual testing