### PR TITLE
Update the Contributing Docs ready for Open Contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,40 +1,117 @@
-## How to contribute to Datapane
+# Contributing to Datapane
 
-#### **How is Datapane developed?**
+## How is Datapane developed?
 
 Datapane CLI and library is an open-source product developed by the Datapane team and open-source contributors.
 
-To ease development we do most development within an internal monorepo and mirror changes to this repo directly as they are commited.
+For ease of development across multiple projects, we maintain our code within a public monorepo.
 
-We really value open-source contributions and PRs to this repo. Our process for integrating them into our workflow is to merge the PR to this repo,
-merge the changes back into to our monorepo, and then repush them back here - this may alter the commit hashes but not the history - ensuring that you correctly attributed for your PR and commits.
+For making Code changes, just open a PR, have it reviewed, and we'll merge it when ready.
 
-#### **Did you find a bug?**
+### Regarding End-to-end tests
+
+Datapane Teams is maintained in a separate private repo (referred to as `datapane-hosted`), which has the public monorepo nested within it as a Git Submodule.
+
+This is to allow cross-project when we're working on the backend (easier e2e testing).
+
+Crucially, this means End-to-end tests will not run for public contributions.
+
+For now, it's recommended to use your judgement:
+
+-   smaller contributions can forgo the e2e tests, which can be fixed retroactively by one of our staff; Or
+-   A temporary PR updating the submodule to point at the Contributor's Fork
+    -   Be mindful that this allows untrusted code to be run within our Private Repo
+
+The longer term plan is to provide a way to run e2e tests for the public directly.
+
+## Navigating the Repo
+
+We maintain a Multi-language Monorepo.
+This is to simplify cross-project work without the overhead of multiple repositories hanging around.
+
+However, you should be able to work on one project without needing to be aware of the other projects.
+
+### Structure
+
+There are 4 directories to be aware of:
+
+#### Root (`./`)
+
+The Root of the repository holds any repo-level files relating to datapane as a whole.
+
+In here, we'd expect to see things like Git configs, global linting rules, and high-level guidelines.
+
+Generally speaking, if something is for a specific project, it shouldn't live in the root directory.
+
+#### Docs (`./docs`)
+
+The Global Documentation, the home for any and all documentation relating to how to use
+any Datapane product.
+
+This is a great place for contributing examples + guides to.
+
+#### Dev Tools (`./dev`)
+
+The home for any resources relating to managing the repository.
+
+This could be scripts for cross-project dependencies, shared utilities,
+or project templates to act as a reference point.
+
+#### Projects (`./projects/*`)
+
+Any projects live here.
+These could be projects we intend to distribute, or supporting projects that are
+used internally by other projects.
+
+Each project will have a `CONTRIBUTING.md` file to explain how to get started there.
+
+**Notable** projects include:
+
+-   `python-client`: the Datapane CLI + Framework
+-   `web-components`: a Supporting Project which builds components used to render reports
+
+## Ways to Contribute
+
+Whilst this document is aimed at people wanting to work on the codebase, we recognise
+that Contributing is so much more than just writing code.
+
+If you'd like to just ask a question, show off what you're doing, or just hang out with us,
+feel free to drop by our Discord or Forum on our [Community page][community-page].
+
+### Did you find a bug?
 
 -   **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/datapane/datapane/issues).
 
 -   If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/datapane/datapane/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
-#### **Did you write a patch that fixes a bug?**
+### Did you write a patch that fixes a bug?
 
 -   Open a new GitHub pull request with the patch.
 
 -   Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
-#### **Do you intend to add a new feature or change an existing one?**
+### Do you intend to add a new feature or change an existing one?
 
 -   That's great - it's always good to hear feedback and new ideas!
 
--   If it's a large feature, consider discussing on our [discussions board](https://github.com/datapane/datapane/discussions) and start writing code.
+-   Check to see if it's been discussed already in our [Forum][forum]
 
-#### **Do you have questions about the source code?**
+-   Open up a new Thread in the [Forum][forum] so we can start chatting about your needs!
 
--   Ask any questions on our [GitHub discussions board](https://github.com/datapane/datapane/discussions).
+### Do you have questions about the source code?
 
-#### **Do you want to contribute to the Datapane community?**
+-   Feel free to drop by to [Chat][chat], or post a question in the [Forum][forum]!
+
+### Do you want to contribute to the Datapane community?
 
 Datapane is a joint startup and community effort. We encourage you to pitch in and join to add any features you are interested in!
+
+Feel free to come [Chat][chat] with us!
 
 Thanks! :heart: :heart: :heart:
 
 Datapane Team
+
+[community-page]: https://datapane.com/community
+[chat]: https://chat.datapane.com/
+[forum]: https://forum.datapane.com/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,40 @@
 # Contributing to Datapane
 
-## How is Datapane developed?
+## How is Datapane Framework developed?
 
-Datapane CLI and library is an open-source product developed by the Datapane team and open-source contributors.
+Datapane Framework is an open-source product developed by Datapane and open-source contributors.
 
-For ease of development across multiple projects, we maintain our code within a public monorepo.
+For ease of development across the multiple projects, the workspace is maintained within a public, multi-langauge monorepo.
 
-For making Code changes, just open a PR, have it reviewed, and we'll merge it when ready.
+For making changes, just:
+
+1. open a PR
+2. have it reviewed
+3. merge!!
 
 ### Regarding End-to-end tests
 
-Datapane Teams is maintained in a separate private repo (referred to as `datapane-hosted`), which has the public monorepo nested within it as a Git Submodule.
+Datapane Cloud is maintained in a separate private repo, which has the public monorepo nested within it as a Git Submodule.
 
-This is to allow cross-project when we're working on the backend (easier e2e testing).
+This is to ease some pain when working on the backend (easier e2e testing), while still allowing an easy path for public
+contributions to Datapane Framework.
 
 Crucially, this means End-to-end tests will not run for public contributions.
 
 For now, it's recommended to use your judgement:
 
--   smaller contributions can forgo the e2e tests, which can be fixed retroactively by one of our staff; Or
--   A temporary PR updating the submodule to point at the Contributor's Fork
-    -   Be mindful that this allows untrusted code to be run within our Private Repo
+-   smaller contributions can forgo the e2e tests, which can be fixed retroactively by someone with access; or
+-   A temporary PR can be created, updating the submodule to point at the contributor's fork.
+    -   WARNING: Be mindful that this allows untrusted code to be run within the private repo (without secrets).
 
 The longer term plan is to provide a way to run e2e tests for the public directly.
 
 ## Navigating the Repo
 
-We maintain a Multi-language Monorepo.
+The repo is made up of multiple projects of different languages.
 This is to simplify cross-project work without the overhead of multiple repositories hanging around.
 
-However, you should be able to work on one project without needing to be aware of the other projects.
+However, you should still be able to work on one project without needing to be aware of the others.
 
 ### Structure
 
@@ -37,22 +42,24 @@ There are 4 directories to be aware of:
 
 #### Root (`./`)
 
-The Root of the repository holds any repo-level files relating to datapane as a whole.
+The root of the repository holds any files that apply to all projects.
 
-In here, we'd expect to see things like Git configs, global linting rules, and high-level guidelines.
+This could include:
+
+-   High-level documentation
+-   Workspace configurations
 
 Generally speaking, if something is for a specific project, it shouldn't live in the root directory.
 
 #### Docs (`./docs`)
 
-The Global Documentation, the home for any and all documentation relating to how to use
-any Datapane product.
+The home for any and all documentation relating to how to use Datapane Framework.
 
 This is a great place for contributing examples + guides to.
 
 #### Dev Tools (`./dev`)
 
-The home for any resources relating to managing the repository.
+The home for any resources relating to managing the workspace.
 
 This could be scripts for cross-project dependencies, shared utilities,
 or project templates to act as a reference point.
@@ -60,8 +67,8 @@ or project templates to act as a reference point.
 #### Projects (`./projects/*`)
 
 Any projects live here.
-These could be projects we intend to distribute, or supporting projects that are
-used internally by other projects.
+These could be projects for public distribution, or supporting projects that are
+used internally within the workspace.
 
 Each project will have a `CONTRIBUTING.md` file to explain how to get started there.
 
@@ -72,11 +79,11 @@ Each project will have a `CONTRIBUTING.md` file to explain how to get started th
 
 ## Ways to Contribute
 
-Whilst this document is aimed at people wanting to work on the codebase, we recognise
-that Contributing is so much more than just writing code.
+Whilst this document is aimed at people wanting to work on the codebase, we recognize
+that contributing is so much more than just writing code.
 
 If you'd like to just ask a question, show off what you're doing, or just hang out with us,
-feel free to drop by our Discord or Forum on our [Community page][community-page].
+feel free to drop by our Discord server or forum, found on our [community page][community-page].
 
 ### Did you find a bug?
 
@@ -88,25 +95,25 @@ feel free to drop by our Discord or Forum on our [Community page][community-page
 
 -   Open a new GitHub pull request with the patch.
 
--   Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+-   Ensure the PR description clearly describes the problem and solution. Include the relevant issue number, if applicable.
 
 ### Do you intend to add a new feature or change an existing one?
 
 -   That's great - it's always good to hear feedback and new ideas!
 
--   Check to see if it's been discussed already in our [Forum][forum]
+-   Check to see if it's been discussed already in our [forum][forum]
 
--   Open up a new Thread in the [Forum][forum] so we can start chatting about your needs!
+-   Open up a new Thread in the [forum][forum], we can start chatting about your needs!
 
 ### Do you have questions about the source code?
 
--   Feel free to drop by to [Chat][chat], or post a question in the [Forum][forum]!
+-   Feel free to drop by to [chat][chat], or post a question in the [forum][forum]!
 
 ### Do you want to contribute to the Datapane community?
 
 Datapane is a joint startup and community effort. We encourage you to pitch in and join to add any features you are interested in!
 
-Feel free to come [Chat][chat] with us!
+Feel free to come [chat][chat] with us!
 
 Thanks! :heart: :heart: :heart:
 


### PR DESCRIPTION
- Clean up headers
- Point to the new Community Areas
- expose the e2e testing limitation
- document the new directory structure

To note:
Currently only addresses the top-level Contributing Guide, I'm not looking to set them up in this PR as I'd like to chat with someone about them first.

For convenience, [rendered view](https://github.com/datapane/datapane/blob/chore/dev-contributions/CONTRIBUTING.md)