### PR TITLE
Fix `vue-eslint-parser module not found` ESlint error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,6 +135,7 @@ repos:
            - tslint@5.20.0
            - eslint-plugin-vue@v7.5.0
            - "@typescript-eslint/eslint-plugin-tslint@2.4.0"
+           - "vue-eslint-parser"
   # sh shellcheck
   - repo: https://github.com/detailyang/pre-commit-shell
     rev: "v1.0.6"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,7 +135,7 @@ repos:
            - tslint@5.20.0
            - eslint-plugin-vue@v7.5.0
            - "@typescript-eslint/eslint-plugin-tslint@2.4.0"
-           - "vue-eslint-parser"
+           - "vue-eslint-parser@9.0.3"
   # sh shellcheck
   - repo: https://github.com/detailyang/pre-commit-shell
     rev: "v1.0.6"


### PR DESCRIPTION
fixes https://3.basecamp.com/5309418/buckets/26389214/todos/5133636320

## Prerequsites

- [x] Has been tested locally
- [ ] If a bugfix, have included a breaking test if possible

## Proposed Changes

- Add `vue-eslint-parser` as an `additional_dependency` in pre-commit config so that it's available as a node module for `ESLint`
