### PR TITLE
Chore: Build docs on PR + default branch

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -56,6 +56,15 @@ jobs:
         run: |
           task web-components:install:ci web-components:build:local-report link-local-report
 
+      - name: Login to Datapane
+        working-directory: docs
+        run: |
+          # We're only pushing to the server as a side-effect, we never actually use what we push.
+          # TODO: Implement environment variables to avoid writing the token to disk.
+          poetry run datapane login --token '${{ secrets.DOCS_BUILD_DATAPANE_API_KEY }}'
+
       - name: Build
         run: |
           task docs:build
+
+permissions: {}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -67,4 +67,10 @@ jobs:
         run: |
           task docs:build
 
+      - name: Artifact Docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs-build
+          path: docs/site
+
 permissions: {}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -34,9 +34,10 @@ jobs:
 
       - name: Install Tools
         run: |
-          pipx install "poetry>=1.1.14,<1.2.0"
+          pipx install -f "poetry>=1.1.14,<1.2.0"
           poetry config virtualenvs.in-project true
-          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d
+          # use /home/runner to workaround 'act' running as root for local development (HOME not available)
+          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /home/runner/.local/bin
 
       - name: Dump Runner Info
         env:
@@ -45,8 +46,10 @@ jobs:
           echo "${RUNNER_CONTEXT}"
           which python
 
+
       - name: Install Docs Dependencies
         run: |
+          pushd docs; poetry env use 3.10; popd
           task docs:install
 
       - name: Build (+ Link) Local Report bundle

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,58 @@
+name: Build [Docs]
+
+on:
+  # Docs depends on all projects, so don't path limit it
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build:
+    defaults:
+      run:
+        shell: bash
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable symlinks on Windows
+        run: git config --global core.symlinks true
+        if: startsWith(runner.os, 'Windows')
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Setup Node
+        id: setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install Tools
+        run: |
+          pipx install "poetry>=1.1.14,<1.2.0"
+          poetry config virtualenvs.in-project true
+          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d
+
+      - name: Dump Runner Info
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        run: |
+          echo "${RUNNER_CONTEXT}"
+          which python
+
+      - name: Install Docs Dependencies
+        run: |
+          task docs:install
+
+      - name: Build (+ Link) Local Report bundle
+        run: |
+          task web-components:install:ci web-components:build:local-report link-local-report
+
+      - name: Build
+        run: |
+          task docs:build

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,74 @@
+on:
+  workflow_run:
+    workflows:
+      - Build [Docs]
+    types:
+      - completed
+
+defaults:
+  run:
+    shell: bash
+
+# We use a separate workflow so we don't leak deployment keys in the PR workflows.
+# Keys are tied to the 'docs-deploy' environment, which can only be accessed on the 'master' branch.
+
+# IMPORTANT: You have to merge changes to this file to 'master' before they'll be executed.
+
+# NOTE: We do not checkout any repository (ours or theirs):
+#       - Avoids Remote Code Execution (if we check out their branch)
+#       - Avoids user confusion when changes they make are not reflected (such as changing the Taskfile.yml)
+#       - GitOps based tools (wrangler) need to be configured explicitly
+
+# secrets:
+# DOCS_CLOUDFLARE_PAGES_API_TOKEN::
+# - Grants edit access to Cloudflare Pages on the Datapane Account
+# - TTL of 2 months
+# - instructions here: https://developers.cloudflare.com/api/tokens/create/
+
+# Future:
+# - implement 'workflow_dispatch' so we can manually trigger deploys
+# - implement Github Deployments to associate a deployed page with a PR (better reviews)
+# - Pages Cleanup for merged PR
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclussion == 'success'
+    environment: docs-deploy
+
+    steps:
+      - name: Download Built Dodcs
+        # We're not using 'action/download-artifact' as it doesn't
+        # natively support cross-workflow downloads.
+        # https://github.com/actions/download-artifact/issues/172
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          run_id: ${{ context.payload.workflow_run.id }}
+          # always specify a path to prevent files getting written over
+          # https://www.legitsecurity.com/blog/github-actions-that-open-the-door-to-cicd-pipeline-attacks
+          path: ./work/site
+          name: docs-build
+
+      - name: Ensure site exists
+        working-directory: ./work
+        run: |
+          if ( ! test -f site/index.html ) {
+            echo '::error title=Docs Artifacts not found::Missing the built docs site'
+            exit 1
+          }
+
+      - name: Publish Docs
+        working-directory: ./work
+        run: |
+          npx wrangler pages publish \
+            --project-name datapane-docs \
+            --branch "$DOCS_BRANCH" \
+            --commit "$DOCS_COMMIT" \
+            site
+        env:
+          CLOUDFLARE_API_TOKEN: '${{ secrets.DOCS_CLOUDFLARE_PAGES_API_TOKEN }}'
+          # indirect access to prevent shell escape issues
+          DOCS_BRANCH: '${{ context.payload.workflow_run.head_branch }}'
+          DOCS_COMMIT: '${{ context.payload.workflow_run.head_sha }}'
+
+permissions: {}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,7 @@ defaults:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclussion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     environment: docs-deploy
 
     steps:
@@ -43,7 +43,7 @@ jobs:
         # https://github.com/actions/download-artifact/issues/172
         uses: dawidd6/action-download-artifact@v2
         with:
-          run_id: ${{ context.payload.workflow_run.id }}
+          run_id: ${{ github.event.workflow_run.id }}
           # always specify a path to prevent files getting written over
           # https://www.legitsecurity.com/blog/github-actions-that-open-the-door-to-cicd-pipeline-attacks
           path: ./work/site
@@ -68,7 +68,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: '${{ secrets.DOCS_CLOUDFLARE_PAGES_API_TOKEN }}'
           # indirect access to prevent shell escape issues
-          DOCS_BRANCH: '${{ context.payload.workflow_run.head_branch }}'
-          DOCS_COMMIT: '${{ context.payload.workflow_run.head_sha }}'
+          DOCS_BRANCH: '${{ github.event.workflow_run.head_branch }}'
+          DOCS_COMMIT: '${{ github.event.workflow_run.head_sha }}'
 
 permissions: {}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,3 +8,19 @@ includes:
   docs:
     taskfile: docs
     dir: docs
+
+  web-components:
+    taskfile: projects/web-components
+    dir: projects/web-components
+
+tasks:
+  link-local-report:
+    desc: Link the local-report artifacts into the python-client codebase (for Report.save)
+    cmds:
+      - |
+        case "$(uname -s)" in
+          Darwin) ln_cmd='ln -svf';;
+          *) ln_cmd='ln -srvf';;
+        esac
+        ${ln_cmd} 'projects/web-components/dist/local-report/local-report-base.js' 'projects/python-client/src/datapane/resources/local_report/local-report-base.js'
+        ${ln_cmd} 'projects/web-components/dist/local-report/local-report-base.css' 'projects/python-client/src/datapane/resources/local_report/local-report-base.css'

--- a/projects/web-components/Taskfile.yml
+++ b/projects/web-components/Taskfile.yml
@@ -1,0 +1,31 @@
+version: "3"
+
+includes:
+
+env:
+
+tasks:
+  install:
+    desc: "Install dependencies ready for development on the codebase"
+    run: once
+    cmds:
+      - npm install
+  install:ci:
+    desc: "Install dependencies for the CI environment"
+    cmds:
+      - npm clean-install
+
+  test:
+    desc: "Run self-contained tests"
+
+  build:
+    desc: "Build a package ready for a deploy"
+    cmds:
+      - npm run build
+  build:local-report:
+    desc: "Build local-report artifacts for inclusion in other projects"
+    cmds:
+      - npm run build:local-report
+
+  deploy:
+    desc: "Deploy the package"


### PR DESCRIPTION
- Introduces some tooling to help with generating/using the local-reports bundle (run `task -l` for more details)
- Setup a base workflow for running builds