### PR TITLE
Cache Google Trends data in docs

### DIFF
--- a/docs/docs/guides/accessing-data-in-python/accessing-data-in-python.ipynb
+++ b/docs/docs/guides/accessing-data-in-python/accessing-data-in-python.ipynb
@@ -866,9 +866,138 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3dd9e723-34b8-4ff4-b8c0-b9142267aa07",
+   "metadata": {
+    "tags": [
+     "remove_all_output"
+    ]
+   },
+   "source": [
+    "```python\n",
+    "import pandas as pd\n",
+    "from pytrends.request import TrendReq\n",
+    "\n",
+    "pytrends = TrendReq()\n",
+    "keywords = [\"oat milk\", \"soy milk\", \"almond milk\"]\n",
+    "pytrends.build_payload(\n",
+    "    keywords, cat=0, geo=\"\", gprop=\"\"\n",
+    ")  # Get data from the last 5 years\n",
+    "top_queries = pytrends.interest_over_time()[keywords]\n",
+    "top_queries.to_csv('top_queries.csv')\n",
+    "```\n",
+    "\n",
+    "Our Google Trends data is now in `top_queries.csv`. "
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "11027291-20e4-4a5a-a410-1c7293baf5ca",
+   "execution_count": 9,
+   "id": "a37b9ebe-87bf-449b-8633-f7cc2e678052",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>oat milk</th>\n",
+       "      <th>soy milk</th>\n",
+       "      <th>almond milk</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2017-08-06</td>\n",
+       "      <td>5</td>\n",
+       "      <td>23</td>\n",
+       "      <td>72</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2017-08-13</td>\n",
+       "      <td>4</td>\n",
+       "      <td>23</td>\n",
+       "      <td>70</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2017-08-20</td>\n",
+       "      <td>4</td>\n",
+       "      <td>24</td>\n",
+       "      <td>66</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2017-08-27</td>\n",
+       "      <td>4</td>\n",
+       "      <td>20</td>\n",
+       "      <td>61</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2017-09-03</td>\n",
+       "      <td>4</td>\n",
+       "      <td>23</td>\n",
+       "      <td>64</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         date  oat milk  soy milk  almond milk\n",
+       "0  2017-08-06         5        23           72\n",
+       "1  2017-08-13         4        23           70\n",
+       "2  2017-08-20         4        24           66\n",
+       "3  2017-08-27         4        20           61\n",
+       "4  2017-09-03         4        23           64"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "top_queries = pd.read_csv('top_queries.csv')\n",
+    "top_queries.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "167f3043-682b-4b47-911b-37ba843c4113",
+   "metadata": {
+    "tags": [
+     "remove_all_output"
+    ]
+   },
+   "source": [
+    "Let's read it into a `DataFrame` and create a report:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "73c40b90-b6e1-4247-8054-bfef223ec2f1",
    "metadata": {
     "tags": [
      "remove_all_output"
@@ -889,18 +1018,7 @@
     }
    ],
    "source": [
-    "import pandas as pd\n",
-    "from pytrends.request import TrendReq\n",
-    "\n",
-    "pytrends = TrendReq()\n",
-    "keywords = [\"oat milk\", \"soy milk\", \"almond milk\"]\n",
-    "pytrends.build_payload(\n",
-    "    keywords, cat=0, geo=\"\", gprop=\"\"\n",
-    ")  # Get data from the last 5 years\n",
-    "top_queries = pytrends.interest_over_time()[keywords]\n",
-    "\n",
-    "top_queries.head()\n",
-    "report = dp.Report(cdc500_df)\n",
+    "report = dp.Report(top_queries)\n",
     "report.save(path=\"accessing-pytrends-data.html\")"
    ]
   },
@@ -974,8 +1092,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/docs/docs/guides/accessing-data-in-python/accessing-data-in-python.ipynb
+++ b/docs/docs/guides/accessing-data-in-python/accessing-data-in-python.ipynb
@@ -996,7 +996,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "73c40b90-b6e1-4247-8054-bfef223ec2f1",
    "metadata": {
     "tags": [
@@ -1018,7 +1018,10 @@
     }
    ],
    "source": [
-    "report = dp.Report(top_queries)\n",
+    "report = dp.Report(\n",
+    "    \"Data source: Google Trends (https://www.google.com/trends).\", top_queries\n",
+    ")\n",
+    "\n",
     "report.save(path=\"accessing-pytrends-data.html\")"
    ]
   },

--- a/docs/docs/guides/accessing-data-in-python/top_queries.csv
+++ b/docs/docs/guides/accessing-data-in-python/top_queries.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23607d1576ec5456596f912394944867e67cf3ea1343fe5b6993f68f0bbb5814
+size 5182


### PR DESCRIPTION
Thank you so much for contributing to Datapane, please help us by filing out this PR template and ensure you have read the [CONTRIBUTING.md](../CONTRIBUTING.md).

It may take a few days to review your PR and merge it - please bear with us!

Thanks!

## Prerequsites

- [x] Has been tested locally
- [ ] If a bugfix, have included a breaking test if possible

## Proposed Changes

Addressing comment from our Discord https://discord.com/channels/983736148746715158/999322544895180901/1003977799662571600:

> Pytrends hits Google, which is doing bot detection.
> We're likely to see more 429s: https://github.com/datapane/datapane/runs/7629659533?check_suite_focus=true#step:11:130
> Suggest we only use publicly available APIs

The PyTrends operations have been switched to a markdown cell. The cell now includes code to save the data to a CSV.

In the following code cell, this data is loaded into a DataFrame and used to create a report.