### PR TITLE
chore: Update GH edit uri for docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Datapane Docs
 repo_name: datapane/datapane
-repo_url: https://github.com/datapane/datapane
+repo_url: https://github.com/datapane/datapane/
+edit_uri: 'edit/master/docs/docs/'
 copyright: © 2022 <a href="https://datapane.com" target="_blank">Datapane</a>. All rights reserved.
 
 nav:


### PR DESCRIPTION
Thank you so much for contributing to Datapane, please help us by filing out this PR template and ensure you have read the [CONTRIBUTING.md](../CONTRIBUTING.md).

It may take a few days to review your PR and merge it - please bear with us!

Thanks!


## Prerequsites

- [x] Has been tested locally
- [ ] If a bugfix, have included a breaking test if possible

## Proposed Changes

The edit button was broken on our docs (hits a 404 page on GH). The fix is to set `edit_uri: 'edit/master/docs/docs/'`, where the default was `edit_uri: 'edit/master/docs/'`.