### PR TITLE
Fixed E2E test that failed when run against prod

### DIFF
--- a/projects/python-client/tests/client/e2e/test_reports.py
+++ b/projects/python-client/tests/client/e2e/test_reports.py
@@ -44,15 +44,21 @@ def test_report_update_metadata():
     report.upload(name, **props)
 
     with deletable(report):
-        for (k, v) in props.items():
-            assert sorted(report.dto[k]) == sorted(v)
+
+        def check_props():
+            assert report.dto["description"] == props["description"]
+            assert report.dto["source_url"] == props["source_url"]
+            assert sorted(report.dto["tags"]) == sorted(props["tags"])
+            assert report.dto["publicly_visible"] == props.get("publicly_visible", False)
+
+        check_props()
         orig_dto = deepcopy(report.dto)
 
         # overwrite and upload again, using defaults
         report.upload(name, overwrite=True)
-        # check props haven't changed
-        for (k, v) in props.items():
-            assert sorted(report.dto[k]) == sorted(v)
+
+        # check specified props haven't changed
+        check_props()
 
         # check other elements haven't changed?
         for x in same_props:


### PR DESCRIPTION

## Proposed Changes

Fix for test that failed on deployment due to different config - https://github.com/datapane/datapane-hosted/runs/8088926100?check_suite_focus=true#step:13:2052

I rewrote to use a more robust pattern - the `sorted()` logic was in fact only appropriate for the `tags` field which is unsorted by nature, for other fields we can't assume it. So it's easier to just list the fields.

