### PR TITLE
Match python and JS Altair libraries

### DIFF
--- a/projects/web-components/package-lock.json
+++ b/projects/web-components/package-lock.json
@@ -45,7 +45,7 @@
                 "uuid": "^8.3.2",
                 "vega": "^5.22.0",
                 "vega-embed": "^6.20.8",
-                "vega-lite": "^5.2.0",
+                "vega-lite": "^4.17.0",
                 "vue": "^3.2.25",
                 "vue-eslint-parser": "^9.0.3",
                 "vue-multiselect": "^3.0.0-alpha.2",
@@ -5237,6 +5237,15 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
             "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
             "dev": true
+        },
+        "node_modules/@types/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-IyNhGHu71jH1jCXTHmafuoAAdsbBON3kDh7u/UUhLmjYgN5TYB54e1R8ckTCiIevl2UuZaCsi9XRxineY5yUjw==",
+            "deprecated": "This is a stub types definition. fast-json-stable-stringify provides its own type definitions, so you do not need this installed.",
+            "dependencies": {
+                "fast-json-stable-stringify": "*"
+            }
         },
         "node_modules/@types/file-saver": {
             "version": "2.0.5",
@@ -23028,21 +23037,22 @@
             }
         },
         "node_modules/vega-lite": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.3.0.tgz",
-            "integrity": "sha512-6giodZ/bJnWyLq6Gj4OyiDt7EndoGyC9f5xDQjo82yPpUiO4MuG9iiPMqR1SPKmG9/qPBf+klWQR0v/7Mgju0Q==",
+            "version": "4.17.0",
+            "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-4.17.0.tgz",
+            "integrity": "sha512-MO2XsaVZqx6iWWmVA5vwYFamvhRUsKfVp7n0pNlkZ2/21cuxelSl92EePZ2YGmzL6z4/3K7r/45zaG8p+qNHeg==",
             "dependencies": {
-                "@types/clone": "~2.1.1",
+                "@types/clone": "~2.1.0",
+                "@types/fast-json-stable-stringify": "^2.0.0",
                 "array-flat-polyfill": "^1.0.1",
                 "clone": "~2.1.2",
                 "fast-deep-equal": "~3.1.3",
                 "fast-json-stable-stringify": "~2.1.0",
-                "json-stringify-pretty-compact": "~3.0.0",
-                "tslib": "~2.4.0",
-                "vega-event-selector": "~3.0.0",
-                "vega-expression": "~5.0.0",
-                "vega-util": "~1.17.0",
-                "yargs": "~17.5.1"
+                "json-stringify-pretty-compact": "~2.0.0",
+                "tslib": "~2.0.3",
+                "vega-event-selector": "~2.0.6",
+                "vega-expression": "~3.0.0",
+                "vega-util": "~1.16.0",
+                "yargs": "~16.0.3"
             },
             "bin": {
                 "vl2pdf": "bin/vl2pdf",
@@ -23050,36 +23060,53 @@
                 "vl2svg": "bin/vl2svg",
                 "vl2vg": "bin/vl2vg"
             },
-            "engines": {
-                "node": ">=12"
-            },
             "peerDependencies": {
-                "vega": "^5.22.0"
+                "vega": "^5.17.0"
             }
+        },
+        "node_modules/vega-lite/node_modules/json-stringify-pretty-compact": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+            "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
+        },
+        "node_modules/vega-lite/node_modules/tslib": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+            "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        },
+        "node_modules/vega-lite/node_modules/vega-event-selector": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.6.tgz",
+            "integrity": "sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew=="
+        },
+        "node_modules/vega-lite/node_modules/vega-expression": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-3.0.1.tgz",
+            "integrity": "sha512-+UwOFEkBnAWo8Zud6i8O4Pd2W6QqmPUOaAhjNtj0OxRL+d+Duoy7M4edUDZ+YuoUcMnjjBFfDQu7oRAA1fIMEQ==",
+            "dependencies": {
+                "vega-util": "^1.15.2"
+            }
+        },
+        "node_modules/vega-lite/node_modules/vega-util": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.1.tgz",
+            "integrity": "sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg=="
         },
         "node_modules/vega-lite/node_modules/yargs": {
-            "version": "17.5.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-            "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
+            "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
             "dependencies": {
-                "cliui": "^7.0.2",
-                "escalade": "^3.1.1",
+                "cliui": "^7.0.0",
+                "escalade": "^3.0.2",
                 "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.0.0"
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.1",
+                "yargs-parser": "^20.0.0"
             },
             "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vega-lite/node_modules/yargs-parser": {
-            "version": "21.0.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-            "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-            "engines": {
-                "node": ">=12"
+                "node": ">=10"
             }
         },
         "node_modules/vega-loader": {
@@ -29083,6 +29110,14 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
             "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
             "dev": true
+        },
+        "@types/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-IyNhGHu71jH1jCXTHmafuoAAdsbBON3kDh7u/UUhLmjYgN5TYB54e1R8ckTCiIevl2UuZaCsi9XRxineY5yUjw==",
+            "requires": {
+                "fast-json-stable-stringify": "*"
+            }
         },
         "@types/file-saver": {
             "version": "2.0.5",
@@ -42938,41 +42973,65 @@
             }
         },
         "vega-lite": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.3.0.tgz",
-            "integrity": "sha512-6giodZ/bJnWyLq6Gj4OyiDt7EndoGyC9f5xDQjo82yPpUiO4MuG9iiPMqR1SPKmG9/qPBf+klWQR0v/7Mgju0Q==",
+            "version": "4.17.0",
+            "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-4.17.0.tgz",
+            "integrity": "sha512-MO2XsaVZqx6iWWmVA5vwYFamvhRUsKfVp7n0pNlkZ2/21cuxelSl92EePZ2YGmzL6z4/3K7r/45zaG8p+qNHeg==",
             "requires": {
-                "@types/clone": "~2.1.1",
+                "@types/clone": "~2.1.0",
+                "@types/fast-json-stable-stringify": "^2.0.0",
                 "array-flat-polyfill": "^1.0.1",
                 "clone": "~2.1.2",
                 "fast-deep-equal": "~3.1.3",
                 "fast-json-stable-stringify": "~2.1.0",
-                "json-stringify-pretty-compact": "~3.0.0",
-                "tslib": "~2.4.0",
-                "vega-event-selector": "~3.0.0",
-                "vega-expression": "~5.0.0",
-                "vega-util": "~1.17.0",
-                "yargs": "~17.5.1"
+                "json-stringify-pretty-compact": "~2.0.0",
+                "tslib": "~2.0.3",
+                "vega-event-selector": "~2.0.6",
+                "vega-expression": "~3.0.0",
+                "vega-util": "~1.16.0",
+                "yargs": "~16.0.3"
             },
             "dependencies": {
-                "yargs": {
-                    "version": "17.5.1",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-                    "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+                "json-stringify-pretty-compact": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+                    "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
+                },
+                "tslib": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+                    "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+                },
+                "vega-event-selector": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.6.tgz",
+                    "integrity": "sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew=="
+                },
+                "vega-expression": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-3.0.1.tgz",
+                    "integrity": "sha512-+UwOFEkBnAWo8Zud6i8O4Pd2W6QqmPUOaAhjNtj0OxRL+d+Duoy7M4edUDZ+YuoUcMnjjBFfDQu7oRAA1fIMEQ==",
                     "requires": {
-                        "cliui": "^7.0.2",
-                        "escalade": "^3.1.1",
-                        "get-caller-file": "^2.0.5",
-                        "require-directory": "^2.1.1",
-                        "string-width": "^4.2.3",
-                        "y18n": "^5.0.5",
-                        "yargs-parser": "^21.0.0"
+                        "vega-util": "^1.15.2"
                     }
                 },
-                "yargs-parser": {
-                    "version": "21.0.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-                    "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+                "vega-util": {
+                    "version": "1.16.1",
+                    "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.1.tgz",
+                    "integrity": "sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg=="
+                },
+                "yargs": {
+                    "version": "16.0.3",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
+                    "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+                    "requires": {
+                        "cliui": "^7.0.0",
+                        "escalade": "^3.0.2",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.0",
+                        "y18n": "^5.0.1",
+                        "yargs-parser": "^20.0.0"
+                    }
                 }
             }
         },

--- a/projects/web-components/package.json
+++ b/projects/web-components/package.json
@@ -57,7 +57,7 @@
         "uuid": "^8.3.2",
         "vega": "^5.22.0",
         "vega-embed": "^6.20.8",
-        "vega-lite": "^5.2.0",
+        "vega-lite": "^4.17.0",
         "vue": "^3.2.25",
         "vue-eslint-parser": "^9.0.3",
         "vue-multiselect": "^3.0.0-alpha.2",


### PR DESCRIPTION
## Prerequsites

- [x] Has been tested locally
- [ ] If a bugfix, have included a breaking test if possible

## Proposed Changes

- Roll back JS `vega-lite` package to v4, as the `altair` python lib doesn't support `vega-lite@5` yet (https://github.com/altair-viz/altair/issues/2425)