### PR TITLE
Fix 182 CLI args parsing

### DIFF
--- a/projects/python-client/src/datapane/client/commands.py
+++ b/projects/python-client/src/datapane/client/commands.py
@@ -320,7 +320,7 @@ def app_list():
 
 
 @app.command()
-@click.option("--parameter", "-p", multiple=True)
+@click.option("--dp-parameter", multiple=True)
 @click.option("--cache/--disable-cache", default=True)
 @click.option("--wait/--no-wait", default=True)
 @click.option("--project")
@@ -328,14 +328,14 @@ def app_list():
 @click.argument("name")
 def run(
     name: str,
-    parameter: Tuple[str],
+    dp_parameter: Tuple[str],
     cache: bool,
     wait: bool,
     project: str,
     show_output: bool,
 ):
     """Run a report"""
-    params = process_cmd_param_vals(parameter)
+    params = process_cmd_param_vals(dp_parameter)
     log.info(f"Running app with parameters {params}")
     app = api.App.get(name, project=project)
     with api_error_handler("Error running app"):
@@ -492,20 +492,20 @@ def schedule():
 
 
 @schedule.command()  # type: ignore[no-redef]
-@click.option("--parameter", "-p", multiple=True)
+@click.option("--dp-parameter", multiple=True)
 @click.argument("name", required=True)
 @click.argument("cron", required=True)
 @click.option("--project")
-def create(name: str, cron: str, parameter: Tuple[str], project: str):
+def create(name: str, cron: str, dp_parameter: Tuple[str], project: str):
     """
     Create a schedule
 
     NAME: Name of the App to run
     CRON: crontab representing the schedule interval
-    PARAMETERS: key/value list of parameters to use when running the app on schedule
+    DP_PARAMETERS: key/value list of parameters to use when running the app on schedule
     [Project]: Project in which the app is present
     """
-    params = process_cmd_param_vals(parameter)
+    params = process_cmd_param_vals(dp_parameter)
     log.info(f"Adding schedule with parameters {params}")
     app_obj = api.App.get(name, project=project)
     schedule_obj = api.Schedule.create(app_obj, cron, params)
@@ -513,20 +513,20 @@ def create(name: str, cron: str, parameter: Tuple[str], project: str):
 
 
 @schedule.command()
-@click.option("--parameter", "-p", multiple=True)
+@click.option("--dp-parameter", multiple=True)
 @click.argument("id", required=True)
 @click.argument("cron", required=False)
-def update(id: str, cron: str, parameter: Tuple[str]):
+def update(id: str, cron: str, dp_parameter: Tuple[str]):
     """
     Add a schedule
 
     ID: ID/URL of the Schedule
     CRON: crontab representing the schedule interval
-    PARAMETERS: key/value list of parameters to use when running the app on schedule
+    DP_PARAMETERS: key/value list of parameters to use when running the app on schedule
     """
 
-    params = process_cmd_param_vals(parameter)
-    assert cron or parameter, "Must update either cron or parameters"
+    params = process_cmd_param_vals(dp_parameter)
+    assert cron or dp_parameter, "Must update either cron or parameters"
 
     log.info(f"Updating schedule with parameters {params}")
 

--- a/projects/python-client/src/datapane/client/utils.py
+++ b/projects/python-client/src/datapane/client/utils.py
@@ -134,10 +134,13 @@ def process_cmd_param_vals(params: Tuple[str, ...]) -> JDict:
 
 def parse_command_line() -> t.Dict[str, t.Any]:
     """Called in library mode to pull any parameters into dp.Config"""
-    parser = argparse.ArgumentParser(description="Datapane additional args", conflict_handler="resolve", add_help=False)
+    parser = argparse.ArgumentParser(
+        description="Datapane additional args",
+        conflict_handler="resolve",
+        add_help=False,
+    )
     parser.add_argument(
-        "--parameter",
-        "-p",
+        "--dp-parameter",
         action="append",
         help="key=value parameters to pass into dp.Params",
         default=[],
@@ -150,4 +153,4 @@ def parse_command_line() -> t.Dict[str, t.Any]:
     sys.argv.append(exe_name)
     sys.argv.extend(remaining_args)
 
-    return process_cmd_param_vals(dp_args.parameter)
+    return process_cmd_param_vals(dp_args.dp_parameter)

--- a/projects/python-client/tests/client/e2e/test_library.py
+++ b/projects/python-client/tests/client/e2e/test_library.py
@@ -13,7 +13,7 @@ def test_arbitrary_arguments_from_cli():
         "pytest",
         test_file_path,
         "-k",
-        "test_pytest_from_cli",
+        "test_datapane_init_from_cli",
         "-p",
         "no:warnings",
     ]
@@ -32,7 +32,7 @@ def test_no_arguments_from_cli():
         "pytest",
         test_file_path,
         "-k",
-        "test_pytest_from_cli",
+        "test_datapane_init_from_cli",
     ]
 
     p = subprocess.run(test_command)
@@ -40,7 +40,7 @@ def test_no_arguments_from_cli():
     assert p.returncode == 0
 
 
-def test_pytest_from_cli():
+def test_datapane_init_from_cli():
     """This test is run by keyword expression from other CLI tests.
     It explicitly imports datapane to ensure __init__ is always executed."""
     import datapane as dp

--- a/projects/python-client/tests/client/e2e/test_library.py
+++ b/projects/python-client/tests/client/e2e/test_library.py
@@ -43,6 +43,6 @@ def test_no_arguments_from_cli():
 def test_datapane_init_from_cli():
     """This test is run by keyword expression from other CLI tests.
     It explicitly imports datapane to ensure __init__ is always executed."""
-    import datapane as dp
+    import datapane as dp   # noqa: F401
 
     assert True

--- a/projects/python-client/tests/client/e2e/test_library.py
+++ b/projects/python-client/tests/client/e2e/test_library.py
@@ -1,0 +1,48 @@
+import subprocess
+import sys
+import os
+
+
+def test_arbitrary_arguments_from_cli():
+    """Running the pytest command with arguments for -p
+    to make sure Datapane doesn't process them."""
+    test_file_path = os.path.realpath(__file__)
+    test_command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        test_file_path,
+        "-k",
+        "test_pytest_from_cli",
+        "-p",
+        "no:warnings",
+    ]
+
+    p = subprocess.run(test_command, capture_output=True)
+
+    assert p.returncode == 0, str(p.stderr).replace("\\n", "\n")
+
+
+def test_no_arguments_from_cli():
+    """Running the pytest command without arguments for -p."""
+    test_file_path = os.path.realpath(__file__)
+    test_command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        test_file_path,
+        "-k",
+        "test_pytest_from_cli",
+    ]
+
+    p = subprocess.run(test_command)
+
+    assert p.returncode == 0
+
+
+def test_pytest_from_cli():
+    """This test is run by keyword expression from other CLI tests.
+    It explicitly imports datapane to ensure __init__ is always executed."""
+    import datapane as dp
+
+    assert True

--- a/projects/python-client/tests/client/e2e/test_library.py
+++ b/projects/python-client/tests/client/e2e/test_library.py
@@ -43,6 +43,6 @@ def test_no_arguments_from_cli():
 def test_datapane_init_from_cli():
     """This test is run by keyword expression from other CLI tests.
     It explicitly imports datapane to ensure __init__ is always executed."""
-    import datapane as dp   # noqa: F401
+    import datapane as dp  # noqa: F401
 
     assert True

--- a/projects/python-client/tests/client/e2e/test_library.py
+++ b/projects/python-client/tests/client/e2e/test_library.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 
 
-def test_arbitrary_arguments_from_cli():
+def test_pytest_arguments_from_cli():
     """Running the pytest command with arguments for -p
     to make sure Datapane doesn't process them."""
     test_file_path = os.path.realpath(__file__)
@@ -23,7 +23,7 @@ def test_arbitrary_arguments_from_cli():
     assert p.returncode == 0, str(p.stderr).replace("\\n", "\n")
 
 
-def test_no_arguments_from_cli():
+def test_no_pytest_arguments_from_cli():
     """Running the pytest command without arguments for -p."""
     test_file_path = os.path.realpath(__file__)
     test_command = [
@@ -33,6 +33,55 @@ def test_no_arguments_from_cli():
         test_file_path,
         "-k",
         "test_datapane_init_from_cli",
+    ]
+
+    p = subprocess.run(test_command)
+
+    assert p.returncode == 0
+
+
+def test_correctly_formatted_dp_parameter_arguments_from_cli():
+    """Running a Python program with correctly formatted arguments for
+    --dp-parameter to make sure Datapane doesn't fail when imported."""
+    test_command = [
+        sys.executable,
+        "-c",
+        "import datapane",
+        "--dp-parameter",
+        "my_param=arg",
+    ]
+
+    p = subprocess.run(test_command)
+
+    assert p.returncode == 0
+
+
+def test_incorrectly_formatted_dp_parameter_arguments_from_cli():
+    """Running a Python program with incorrectly formatted arguments for
+    --dp-parameter to make sure Datapane fails when imported."""
+    test_command = [
+        sys.executable,
+        "-c",
+        "import datapane",
+        "--dp-parameter",
+        "my_param:arg",
+    ]
+
+    p = subprocess.run(test_command)
+
+    # Should fail, we're passing in badly formatted args to --dp-parameter
+    assert p.returncode != 0
+
+
+def test_arbitrary_arguments_from_cli():
+    """Running a Python program with arbitrary arguments for -arbs
+    to make sure Datapane doesn't process them when imported."""
+    test_command = [
+        sys.executable,
+        "-c",
+        "import datapane",
+        "-arbs",
+        "my_param:arg",
     ]
 
     p = subprocess.run(test_command)

--- a/projects/python-client/tests/client/e2e/test_library.py
+++ b/projects/python-client/tests/client/e2e/test_library.py
@@ -1,6 +1,6 @@
+import os
 import subprocess
 import sys
-import os
 
 
 def test_arbitrary_arguments_from_cli():


### PR DESCRIPTION
Thank you so much for contributing to Datapane, please help us by filing out this PR template and ensure you have read the [CONTRIBUTING.md](../CONTRIBUTING.md).

It may take a few days to review your PR and merge it - please bear with us!

Thanks!

fixes #182 

## Prerequsites

- [x] Has been tested locally
- [x] If a bugfix, have included a breaking test if possible

## Proposed Changes

- Datapane updated to use `--dp-parameters` rather than `--parameters` and `-p`. This is the case for `DPMode.LIBRARY`, and the `run()`, `create()`, and `update()` commands (@mands will this break CI?).
- Added tests in `test_library.py` for #182 (a CLI command that imports datapane).