### PR TITLE
Fix 274 Remove binary column processing for DataTable

### DIFF
--- a/projects/python-client/src/datapane/common/df_processor.py
+++ b/projects/python-client/src/datapane/common/df_processor.py
@@ -110,23 +110,6 @@ def obj_to_str(df: pd.DataFrame):
     df[df_cat.columns] = df_cat.apply(to_str_cat_vals)
 
 
-def bipartite_to_bool(df: pd.DataFrame):
-    """Converts biperatite numeric {0, 1} columns to bool"""
-    # Get names of numeric columns with only 2 unique values.
-    df_num = df.select_dtypes("integer", exclude=["timedelta"])
-    bipartite_columns = df_num.columns[df_num.dropna().nunique() == 2]
-
-    for column in bipartite_columns:
-        series = df[column]
-
-        # Only apply the type change to {0, 1} columns
-        val_range = series.min(), series.max()
-        val_min, val_max = val_range[0], val_range[1]
-
-        if val_min == 0 and val_max == 1:
-            df[column] = df[column].astype(bool)
-
-
 def str_to_arrow_str(df: pd.DataFrame):
     """Use the memory-efficient pyarrow string dtype (pandas >= 1.3 only)"""
     # convert objects to str / NA
@@ -174,7 +157,6 @@ def process_df(df: pd.DataFrame, copy: bool = False) -> pd.DataFrame:
     # df[td_col.columns] = td_col
     obj_to_str(df)
     parse_categories(df)
-    bipartite_to_bool(df)
 
     # convert all strings to use the arrow dtype
     str_to_arrow_str(df)

--- a/projects/python-client/src/datapane/common/df_processor.py
+++ b/projects/python-client/src/datapane/common/df_processor.py
@@ -110,6 +110,24 @@ def obj_to_str(df: pd.DataFrame):
     df[df_cat.columns] = df_cat.apply(to_str_cat_vals)
 
 
+def bipartite_to_bool(df: pd.DataFrame):
+    # This was removed from our processing steps as some users required the numerical representation of binary columns.
+    """Converts biperatite numeric {0, 1} columns to bool."""
+    # Get names of numeric columns with only 2 unique values.
+    df_num = df.select_dtypes("integer", exclude=["timedelta"])
+    bipartite_columns = df_num.columns[df_num.dropna().nunique() == 2]
+
+    for column in bipartite_columns:
+        series = df[column]
+
+        # Only apply the type change to {0, 1} columns
+        val_range = series.min(), series.max()
+        val_min, val_max = val_range[0], val_range[1]
+
+        if val_min == 0 and val_max == 1:
+            df[column] = df[column].astype(bool)
+
+
 def str_to_arrow_str(df: pd.DataFrame):
     """Use the memory-efficient pyarrow string dtype (pandas >= 1.3 only)"""
     # convert objects to str / NA


### PR DESCRIPTION
Thank you so much for contributing to Datapane, please help us by filing out this PR template and ensure you have read the [CONTRIBUTING.md](../CONTRIBUTING.md).

It may take a few days to review your PR and merge it - please bear with us!

Thanks!

fixes #274

## Prerequsites

- [x] Has been tested locally

## Proposed Changes

Remove the bipartite_to_binary DataTable optimisation. 

Whilst it did reduce file size, the output was not desirable by some users (e.g. #274). We should re-visit this in future as it's a useful (and common) optimisation!