### PR TITLE
Improved fix for #182

### DIFF
--- a/projects/python-client/src/datapane/__init__.py
+++ b/projects/python-client/src/datapane/__init__.py
@@ -109,6 +109,7 @@ __all__ = [
     "_setup_dp_logging",
     "enable_logging",
     "log",
+    "load_params_from_command_line",
 ]
 
 
@@ -126,7 +127,10 @@ else:
 # only init fully in library-mode, as framework and app init explicitly
 if get_dp_mode() == DPMode.LIBRARY:
     init()
-    # parse any commandline params
+
+
+def load_params_from_command_line() -> None:
+    """Call this from your own scripts to read any CLI parameters into the global Params object"""
     from .client.utils import parse_command_line
 
     config = parse_command_line()

--- a/projects/python-client/src/datapane/client/commands.py
+++ b/projects/python-client/src/datapane/client/commands.py
@@ -320,7 +320,7 @@ def app_list():
 
 
 @app.command()
-@click.option("--dp-parameter", multiple=True)
+@click.option("--parameter", "-p", multiple=True)
 @click.option("--cache/--disable-cache", default=True)
 @click.option("--wait/--no-wait", default=True)
 @click.option("--project")
@@ -328,14 +328,14 @@ def app_list():
 @click.argument("name")
 def run(
     name: str,
-    dp_parameter: Tuple[str],
+    parameter: Tuple[str],
     cache: bool,
     wait: bool,
     project: str,
     show_output: bool,
 ):
     """Run a report"""
-    params = process_cmd_param_vals(dp_parameter)
+    params = process_cmd_param_vals(parameter)
     log.info(f"Running app with parameters {params}")
     app = api.App.get(name, project=project)
     with api_error_handler("Error running app"):
@@ -492,20 +492,20 @@ def schedule():
 
 
 @schedule.command()  # type: ignore[no-redef]
-@click.option("--dp-parameter", multiple=True)
+@click.option("--parameter", "-p", multiple=True)
 @click.argument("name", required=True)
 @click.argument("cron", required=True)
 @click.option("--project")
-def create(name: str, cron: str, dp_parameter: Tuple[str], project: str):
+def create(name: str, cron: str, parameter: Tuple[str], project: str):
     """
     Create a schedule
 
     NAME: Name of the App to run
     CRON: crontab representing the schedule interval
-    DP_PARAMETERS: key/value list of parameters to use when running the app on schedule
+    PARAMETERS: key/value list of parameters to use when running the app on schedule
     [Project]: Project in which the app is present
     """
-    params = process_cmd_param_vals(dp_parameter)
+    params = process_cmd_param_vals(parameter)
     log.info(f"Adding schedule with parameters {params}")
     app_obj = api.App.get(name, project=project)
     schedule_obj = api.Schedule.create(app_obj, cron, params)
@@ -513,20 +513,20 @@ def create(name: str, cron: str, dp_parameter: Tuple[str], project: str):
 
 
 @schedule.command()
-@click.option("--dp-parameter", multiple=True)
+@click.option("--parameter", "-p", multiple=True)
 @click.argument("id", required=True)
 @click.argument("cron", required=False)
-def update(id: str, cron: str, dp_parameter: Tuple[str]):
+def update(id: str, cron: str, parameter: Tuple[str]):
     """
     Add a schedule
 
     ID: ID/URL of the Schedule
     CRON: crontab representing the schedule interval
-    DP_PARAMETERS: key/value list of parameters to use when running the app on schedule
+    PARAMETERS: key/value list of parameters to use when running the app on schedule
     """
 
-    params = process_cmd_param_vals(dp_parameter)
-    assert cron or dp_parameter, "Must update either cron or parameters"
+    params = process_cmd_param_vals(parameter)
+    assert cron or parameter, "Must update either cron or parameters"
 
     log.info(f"Updating schedule with parameters {params}")
 

--- a/projects/python-client/src/datapane/client/utils.py
+++ b/projects/python-client/src/datapane/client/utils.py
@@ -133,14 +133,15 @@ def process_cmd_param_vals(params: Tuple[str, ...]) -> JDict:
 
 
 def parse_command_line() -> t.Dict[str, t.Any]:
-    """Called in library mode to pull any parameters into dp.Config"""
+    """Called in library mode to read any datapane CLI parameters"""
     parser = argparse.ArgumentParser(
         description="Datapane additional args",
         conflict_handler="resolve",
         add_help=False,
     )
     parser.add_argument(
-        "--dp-parameter",
+        "--parameter",
+        "-p",
         action="append",
         help="key=value parameters to pass into dp.Params",
         default=[],
@@ -153,4 +154,4 @@ def parse_command_line() -> t.Dict[str, t.Any]:
     sys.argv.append(exe_name)
     sys.argv.extend(remaining_args)
 
-    return process_cmd_param_vals(dp_args.dp_parameter)
+    return process_cmd_param_vals(dp_args.parameter)

--- a/projects/python-client/tests/client/e2e/test_library.py
+++ b/projects/python-client/tests/client/e2e/test_library.py
@@ -40,14 +40,14 @@ def test_no_pytest_arguments_from_cli():
     assert p.returncode == 0
 
 
-def test_correctly_formatted_dp_parameter_arguments_from_cli():
+def test_correctly_formatted_parameter_arguments_from_cli():
     """Running a Python program with correctly formatted arguments for
-    --dp-parameter to make sure Datapane doesn't fail when imported."""
+    --parameter to make sure Datapane doesn't fail when imported."""
     test_command = [
         sys.executable,
         "-c",
         "import datapane",
-        "--dp-parameter",
+        "--parameter",
         "my_param=arg",
     ]
 
@@ -56,14 +56,14 @@ def test_correctly_formatted_dp_parameter_arguments_from_cli():
     assert p.returncode == 0
 
 
-def test_incorrectly_formatted_dp_parameter_arguments_from_cli():
+def test_incorrectly_formatted_parameter_arguments_from_cli():
     """Running a Python program with incorrectly formatted arguments for
-    --dp-parameter to make sure Datapane fails when imported."""
+    --parameter to make sure Datapane fails when imported."""
     test_command = [
         sys.executable,
         "-c",
-        "import datapane",
-        "--dp-parameter",
+        "import datapane; datapane.load_params_from_command_line()",
+        "--parameter",
         "my_param:arg",
     ]
 
@@ -86,6 +86,25 @@ def test_arbitrary_arguments_from_cli():
 
     p = subprocess.run(test_command)
 
+    assert p.returncode == 0
+
+
+def test_parameter_parsing_for_library():
+    """Running a Python program which uses load_params_from_command_line should work"""
+    test_command = [
+        sys.executable,
+        "-c",
+        "import datapane; datapane.load_params_from_command_line(); print(datapane.Params)",
+        "--parameter",
+        "my_param=123",
+    ]
+
+    p = subprocess.run(test_command, capture_output=True)
+
+    # Should have loaded the parameter:
+    assert p.stdout.strip() == b"{'my_param': 123}"
+
+    # And finished without error
     assert p.returncode == 0
 
 


### PR DESCRIPTION
Fixes #182

## Prerequsites

- [X] Has been tested locally
- [X] If a bugfix, have included a breaking test if possible

## Proposed Changes

- change from `--dp-parameter` to `--parameter` (or `-p`), reverting 6cf4f2795c3dd484262f9bdfc64bf4a9b5e82c72 and c86d9125928f4a074ca62eac61cde1e09bda3255, to avoid breaking existing `datapane` CLI usage

- Don't parse command line automatically in library mode. Instead we provide a `load_params_from_command_line` function to do this. Since the original functionality was not documented anywhere, we probably don't need to document this, but can just leave the function somewhere it should be discovered fairly easily for those that need it.


