### PR TITLE
Increase cypress tests timeout

### DIFF
--- a/projects/web-components/cypress.config.ts
+++ b/projects/web-components/cypress.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     viewportHeight: 1050,
     defaultCommandTimeout: 8000,
     includeShadowDom: true,
-    video: false,
+    video: true,
     env: {
         testEmail: "test@datapane.com",
         testPassword: "",

--- a/projects/web-components/cypress.config.ts
+++ b/projects/web-components/cypress.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     viewportHeight: 1050,
     defaultCommandTimeout: 8000,
     includeShadowDom: true,
-    video: true,
+    video: false,
     env: {
         testEmail: "test@datapane.com",
         testPassword: "",

--- a/projects/web-components/cypress/e2e/org/app-run.cy.js
+++ b/projects/web-components/cypress/e2e/org/app-run.cy.js
@@ -101,7 +101,7 @@ describe("Running an app", () => {
         cy.intercept("GET", "**/runs/**").as("getRuns");
         cy.get("[data-cy=button-run]").click();
 
-        cy.wait("@getRuns", { requestTimeout: 10000 });
+        cy.wait("@getRuns", { requestTimeout: 20000 });
         cy.get("#inline-report").should("contain", "__REPORT_RENDERED__");
     });
 });

--- a/projects/web-components/cypress/e2e/org/app-run.cy.js
+++ b/projects/web-components/cypress/e2e/org/app-run.cy.js
@@ -102,6 +102,9 @@ describe("Running an app", () => {
         cy.get("[data-cy=button-run]").click();
 
         cy.wait("@getRuns", { requestTimeout: 20000 });
-        cy.get("#inline-report").should("contain", "__REPORT_RENDERED__");
+        cy.get("#inline-report", { timeout: 20000 }).should(
+            "contain",
+            "__REPORT_RENDERED__"
+        );
     });
 });

--- a/projects/web-components/cypress/e2e/public/report-render.cy.js
+++ b/projects/web-components/cypress/e2e/public/report-render.cy.js
@@ -15,7 +15,7 @@ describe("Report rendering", () => {
     it("Should switch between section tabs successfully", () => {
         cy.scrollToFirst("[data-cy=page-1]").click();
 
-        cy.get("[data-cy=section-tabs]")
+        cy.get("[data-cy=section-tabs]", { timeout: 20000 })
             .eq(2)
             .scrollIntoView()
             .within(() => {

--- a/projects/web-components/cypress/support/commands.js
+++ b/projects/web-components/cypress/support/commands.js
@@ -59,5 +59,5 @@ Cypress.Commands.add("dpSetInitialReport", () => {
 });
 
 Cypress.Commands.add("scrollToFirst", (selector) => {
-    return cy.get(selector).first().scrollIntoView();
+    return cy.get(selector, { timeout: 20000 }).first().scrollIntoView();
 });


### PR DESCRIPTION
## Prerequsites

- [x] Has been tested locally
- [ ] If a bugfix, have included a breaking test if possible

## Proposed Changes

- Increase cypress element find timeout from 8s to 20s, to prevent timeout failures in CI
