### PR TITLE
chore(python-client): Upgrade the default server to cloud.datapane.com

### DIFF
--- a/projects/python-client/tests_toplevel/test_config.py
+++ b/projects/python-client/tests_toplevel/test_config.py
@@ -161,3 +161,18 @@ def test_new_config(mock_analytics, monkeypatch):
         report.save(path="test_out.html", name="My Wicked Report", author="Datapane Team")
         assert posthog.identify.call_count == 1
         assert posthog.capture.call_count == 3
+
+
+def test_upgrade_server(mock_analytics):
+    config_file = """
+    server: https://datapane.com
+    token: REAL_TOKEN
+    """
+    env_name = "upgrade-server"
+    _upgrade_version(mock_analytics, env_name, config_file, identify_calls=1, capture_calls=2)
+
+    from datapane.client import config as c
+
+    new_config = c.Config.load(env_name)
+
+    assert new_config.server == "https://cloud.datapane.com"


### PR DESCRIPTION
- default is now cloud.datapane.com
- upgrade existing configs that used the last default of datapane.com

Testing:
- fresh 'datapane login' without config should add 'server: https://cloud.datapane.com'
- manually change config to 'https://datapane.com'
- 'datapane ping' will upgrade the config, and confirm it connected to 'https://cloud.datapane.com'

