### PR TITLE
fix: explicitly include the report resources in builds

### DIFF
--- a/projects/python-client/pyproject.toml
+++ b/projects/python-client/pyproject.toml
@@ -28,7 +28,13 @@ classifiers = [
 #]
 
 # extra files (allows overriding gitignore)
-include = ["NOTICE", "src/**/local-report-base.*"]  # "README.md", "LICENSE"]
+include = [
+    "NOTICE",
+    "README.md",
+    "LICENSE",
+    "src/datapane/resources/local_report/*",
+    "src/datapane/resources/local_report/report/**/*",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.7.1, < 3.11.0"


### PR DESCRIPTION
Updates the include rules, they're a little looser as there's more than just `local-report.*`

- README and License are explicit now, as we need them for Conda (they were implicitly included before)

