### PR TITLE
Move away from localStorage for PostHog

### DIFF
--- a/projects/web-components/shared/dp-track.ts
+++ b/projects/web-components/shared/dp-track.ts
@@ -44,8 +44,6 @@ export const setupPostHog = async (
                 userId && (await identifyUser(posthog, userId));
                 await mutex.release(LOCK_NAME);
             },
-            persistence: "localStorage",
-            persistence_name: "datapane_store",
         });
     } catch (e) {
         console.error("Posthog setup error", e);


### PR DESCRIPTION
We traditionally used localStorage for PostHog, but we are now cross-domain (e.g. @, cloud., docs.) and localStoage doesn't work cross-domain. I've replaced with the default implementation which uses cross-domain cookies instead.