### PR TITLE
Fix remote report view being emitted in local reports

### DIFF
--- a/projects/web-components/report/src/components/ReportComponent.vue
+++ b/projects/web-components/report/src/components/ReportComponent.vue
@@ -21,7 +21,6 @@ import sanitizeHtml from "sanitize-html";
 const p = defineProps<{
     isOrg: ReportProps["isOrg"];
     mode: ReportProps["mode"];
-    disableTrackViews?: ReportProps["disableTrackViews"];
     htmlHeader?: ReportProps["htmlHeader"];
     report: ReportProps["report"];
 }>();
@@ -34,11 +33,7 @@ onMounted(() => {
         trackLocalReportView("CLI_REPORT_VIEW");
     } else if (window.dpServed && window.dpLocalViewEvent) {
         trackLocalReportView("SERVED_REPORT_VIEW");
-    }
-    {
-        if (p.disableTrackViews) {
-            return;
-        }
+    } else {
         const { web_url, id, published, username, num_blocks } = p.report;
         trackReportView({
             id: id,

--- a/projects/web-components/report/src/components/ReportComponent.vue
+++ b/projects/web-components/report/src/components/ReportComponent.vue
@@ -29,9 +29,9 @@ const pageNumber = ref(0);
 
 onMounted(() => {
     /* View tracking */
-    if (window.dpLocal && window.dpLocalViewEvent) {
+    if (window.dpLocal) {
         trackLocalReportView("CLI_REPORT_VIEW");
-    } else if (window.dpServed && window.dpLocalViewEvent) {
+    } else if (window.dpServed) {
         trackLocalReportView("SERVED_REPORT_VIEW");
     } else {
         const { web_url, id, published, username, num_blocks } = p.report;

--- a/projects/web-components/report/src/data-model/types.ts
+++ b/projects/web-components/report/src/data-model/types.ts
@@ -14,7 +14,6 @@ export type IReport = {
 export type ReportProps = {
     isOrg: boolean;
     mode: "VIEW" | "EMBED";
-    disableTrackViews?: boolean;
     htmlHeader?: string;
     report: IReport;
 };

--- a/projects/web-components/shared/dp-track.ts
+++ b/projects/web-components/shared/dp-track.ts
@@ -136,6 +136,9 @@ export const trackReportView = (properties: ReportViewPayload) => {
 export const trackLocalReportView = (
     event: "CLI_REPORT_VIEW" | "SERVED_REPORT_VIEW"
 ) => {
+    if (!window.dpLocalViewEvent) {
+        return;
+    }
     asyncDPTrackEvent(
         event,
         {


### PR DESCRIPTION
## Prerequsites

- [x] Has been tested locally
- [ ] If a bugfix, have included a breaking test if possible

## Proposed Changes

- Fix if/else statement so that remote views aren't registered in local reports
- Remove `disableTrackViews` prop which was only previously used by the report builder
