### PR TITLE
Support cells to blocks conversion when full Jupyter server is missing in VS Code

### DIFF
--- a/projects/python-client/src/datapane/client/api/ipython_utils.py
+++ b/projects/python-client/src/datapane/client/api/ipython_utils.py
@@ -57,13 +57,15 @@ def get_jupyter_notebook_json() -> dict:
 def get_vscode_notebook_json() -> dict:
     """Get the JSON for the current VSCode notebook"""
     from IPython import get_ipython
+
     ip = get_ipython()
-    
-    if '__vsc_ipynb_file__' in ip.user_ns:
-        nb_path = ip.user_ns['__vsc_ipynb_file__']
+
+    if "__vsc_ipynb_file__" in ip.user_ns:
+        nb_path = ip.user_ns["__vsc_ipynb_file__"]
     else:
         import ipynbname
-        try:     
+
+        try:
             nb_path = ipynbname.path()
 
             # VSCode path name in sesssion is suffixed with -jvsc-[identifier]


### PR DESCRIPTION
Thank you so much for contributing to Datapane, please help us by filing out this PR template and ensure you have read the [CONTRIBUTING.md](../CONTRIBUTING.md).

It may take a few days to review your PR and merge it - please bear with us!

Thanks!



- @antdking reported that `ipynbname` was failing in a VS Code notebook.
- We compared our environments and tried to reproduce it on my machine (Mac OS) with no success.
- It seems @antdking's VS Code does not launch a full Jupyter server.

## Prerequsites

- [x] Has been tested locally
- [ ] If a bugfix, have included a breaking test if possible

## Proposed Changes

We try to get the notebook path using a VSCode-specific key in the user namespace variable first. If it's not there, we fall back to the `ipynbname` approach.