### PR TITLE
Better Matplotlib support - tight bounding box to avoid clipping

### DIFF
--- a/projects/python-client/src/datapane/client/api/files.py
+++ b/projects/python-client/src/datapane/client/api/files.py
@@ -164,7 +164,7 @@ class MatplotBasePlot(PlotAsset):
 
         fn = DPTmpFile(self.ext)
         x = x or plt.gcf()
-        x.savefig(str(fn))
+        x.savefig(str(fn), bbox_inches="tight")
         return fn
 
 


### PR DESCRIPTION
Thank you so much for contributing to Datapane, please help us by filing out this PR template and ensure you have read the [CONTRIBUTING.md](../CONTRIBUTING.md).

It may take a few days to review your PR and merge it - please bear with us!

Thanks!

fixes #320 

## Prerequsites

- [x] Has been tested locally
- [ ] If a bugfix, have included a breaking test if possible

## Proposed Changes

- We're now using "tight" bounding box calculation.

Matplotlib figures appeared to be cropped. This is because we were saving to SVG without setting the bounding box.
