### PR TITLE
fix: root-level single select blocks being treated as single-block embeds

### DIFF
--- a/projects/web-components/report/src/data-model/blocks.ts
+++ b/projects/web-components/report/src/data-model/blocks.ts
@@ -478,4 +478,7 @@ export const isSelect = (obj: any): obj is Select => obj.name === "Select";
 
 export const isToggle = (obj: any): obj is Toggle => obj.name === "Toggle";
 
+export const isLayoutBlock = (obj: any): obj is LayoutBlock =>
+    isGroup(obj) || isSelect(obj) || isToggle(obj);
+
 export const isAssetBlock = (obj: any): obj is AssetBlock => !!obj.src;

--- a/projects/web-components/report/src/data-model/report-store.ts
+++ b/projects/web-components/report/src/data-model/report-store.ts
@@ -4,7 +4,6 @@ import {
     CodeBlock,
     Elem,
     Group,
-    isGroup,
     LayoutBlock,
     Page,
     Report,
@@ -24,6 +23,7 @@ import {
     FoliumBlock,
     PlotapiBlock,
     BigNumberBlock,
+    isLayoutBlock,
 } from "./blocks";
 import convert from "xml-js";
 import * as maps from "./test-maps";
@@ -56,11 +56,11 @@ const isSingleBlockEmbed = (pages: Page[], mode: AppViewMode): boolean => {
      */
     const checkAllGroupsSingle = (node: BlockTree): boolean => {
         /* Check there's a single route down to one leaf node */
-        if (isGroup(node) && node.children.length === 1) {
-            // Node is a Group with a single child
+        if (isLayoutBlock(node) && node.children.length === 1) {
+            // Node is a layout block with a single child
             return checkAllGroupsSingle(node.children[0]);
-        } else if (isGroup(node)) {
-            // Node is a Group with multiple children
+        } else if (isLayoutBlock(node)) {
+            // Node is a layout block with multiple children
             return false;
         } else {
             // Node is a Select or leaf


### PR DESCRIPTION
fixes https://github.com/datapane/datapane/issues/325

## Prerequsites

- [x] Has been tested locally
- [ ] If a bugfix, have included a breaking test if possible

## Proposed Changes

- Fix the `isSingleBlockEmbed` function to recurse through all layout block types instead of just groups
